### PR TITLE
[DNM] temp disable platform name validation

### DIFF
--- a/scripts/pylib/twister/twisterlib/testplan.py
+++ b/scripts/pylib/twister/twisterlib/testplan.py
@@ -989,7 +989,7 @@ class TestPlan:
                 continue
             else:
                 logger.error(f"{log_info} - unrecognized platform - {platform}")
-                sys.exit(2)
+                #sys.exit(2)
 
     def create_build_dir_links(self):
         """


### PR DESCRIPTION
twister won't exit when wrong names found